### PR TITLE
Bug fix for error that prevents generation of config when using mysql

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -104,7 +104,7 @@ function dynroute_get_config($engine) {
 				{
 					$ext->add($c, 's', '', new ext_setvar('connid', ''));
                                 	$ext->add($c, 's', '', new ext_mysql_connect('connid', $dynroute['mysql_host'],  $dynroute['mysql_username'],  $dynroute['mysql_password'],  $dynroute['mysql_dbname']));
-					$ext->add($c, 's', '', new ext_gotoif('$["${connid}" = ""]',$id.',4,1'));
+					$ext->add($c, 's', '', new ext_gotoif('$["${connid}" = ""]',$c.',4,1'));
                                 	$ext->add($c, 's', '', new ext_mysql_query('resultid', 'connid', $query));
 					$ext->add($c, 's', '', new ext_gotoif('$["${resultid}" = ""]',$c.',4,1'));
                                 	$ext->add($c, 's', '', new ext_mysql_fetch('fetchid', 'resultid', 'dynroute')); 


### PR DESCRIPTION
Closes #9 

<code>
A separate fix is also required to a Freepbx file to correct a typo
--- /var/www/html/admin/libraries/extensions.class.php.orig	2024-08-23 18:09:47.329957584 +0200
+++ /var/www/html/admin/libraries/extensions.class.php	2024-08-23 17:48:50.144377102 +0200
@@ -1569,7 +1569,7 @@
 class ext_mysql_fetch extends extension {
 	var $fetchid;
 	var $resultid;
-	var $fars;
+	var $vars;
 
 	function __construct($fetchid, $resultid, $vars) {
 		$this->fetchid = $fetchid;
</code>